### PR TITLE
[Cuphead] Add Auto-reset feature

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,11 @@
+## What game?
+
+> Include this in the title too.
+
+## Why this change? What is the context?
+
+> Explain *what problem you are trying to solve*, without using the solution.
+
+## What did you change?
+
+> Try to make each pull request as small and atomic as possible, they're easier to review that way.

--- a/cuphead/src/settings.rs
+++ b/cuphead/src/settings.rs
@@ -10,13 +10,13 @@ pub enum LevelCompleteSetting {
     /// Split on knockout.
     ///
     /// Usually when the "KNOCKOUT!" text appears on screen, as soon as the boss is dead.
-    #[default]
     OnKnockout,
 
     /// Split after the scorecard screen (except Devil/Saltbaker).
     ///
     /// It can be useful to split after the scorecard since it varies depending on what you do in
     ///   the fight (parries, health, star skip)
+    #[default]
     AfterScorecard,
 
     /// Split after the scorecard screen (except Devil only).
@@ -101,7 +101,7 @@ pub struct Settings {
     pub split_kd_contract_cutscene: bool,
 
     /// Split on mausoleums
-    #[default = false]
+    #[default = true]
     pub split_mausoleum_completion: bool,
 
     /// Split on tutorial completes


### PR DESCRIPTION
## What game?

> Cuphead

## Why this change? What is the context?

> It's a nice feature that saves a keystroke after every run :) though not everyone will want to use it if they want to keep the ability to go back to the title screen, so this is optional and off by default.

## What did you change?

> Add an optional setting to automatically reset the timer when on the title screen. This is off by default.
Resolves #10 