### PR TITLE
[Cuphead] Fix Timer starting at non-zero value sometimes

### DIFF
--- a/cuphead/src/lib.rs
+++ b/cuphead/src/lib.rs
@@ -222,9 +222,8 @@ async fn tick<'a>(
                 && memory.level_time.current()? > 0f32
                 && (!memory.level_is_dice.current()? || memory.lsd_time.current()? == 0f32)))
     {
-        start();
         pause_game_time();
-        set_game_time(asr::time::Duration::seconds_f32(0f32));
+        start();
     }
 
     if state() == TimerState::Running {


### PR DESCRIPTION
## What game?

> Cuphead

## Why this change? What is the context?

> Sometimes the timer would start an count a few milliseconds before pausing. This PR makes sure the timer pauses straight away, then sets the time to 0 straight away (also necessary). This would probably conflict with a user starting with a timer offset, which isn't really important for any types of run for this game, but if deemed valuable enough, this behavior could probably be adjusted with some type of user setting, or alternatively, if there's some kind of API that can dynamically read the timer offset (I have no idea if this exists already) we could read that and apply that to the timer's initial value instead of a hard-coded 0.

## What did you change?

> Pausing the rimer right after starting it, then setting the time to 0. Resolves #13 
