### PR TITLE
[Cuphead] Fix double splitting

### DIFF
--- a/cuphead/src/lib.rs
+++ b/cuphead/src/lib.rs
@@ -287,7 +287,8 @@ async fn tick<'a>(
         }
 
         if scene == SCENE_TITLE_SCREEN && settings.auto_reset
-            || settings.individual_level_mode && level_is_resetting {
+            || settings.individual_level_mode && level_is_resetting
+        {
             reset();
         }
     }


### PR DESCRIPTION
## What game?

Cuphead

## Why this change? What is the context?

#3 

## What did you change?

I think the issue is we don't recalculate "was_on_scoreboard" when the timer isn't running.