### PR TITLE
Fix #19 by including graveyard in the list of levels to split on knockout for

### DIFF
--- a/cuphead/src/settings.rs
+++ b/cuphead/src/settings.rs
@@ -39,11 +39,13 @@ impl LevelCompleteSetting {
             LevelCompleteSetting::AfterScorecard => {
                 level == Levels::Devil
                     || level == Levels::Saltbaker
+                    || level == Levels::Graveyard
                     || level == Levels::Mausoleum
                     || level.get_type() == LevelType::ChessPiece
             }
             LevelCompleteSetting::AfterScorecardIncludingSaltbaker => {
                 level == Levels::Devil
+                    || level == Levels::Graveyard
                     || level == Levels::Mausoleum
                     || level.get_type() == LevelType::ChessPiece
             }


### PR DESCRIPTION
## What game?

Cuphead

## Why this change? What is the context?

Split currently does not work, we want it to work, there is no scorecard on this level.

## What did you change?

Always split on knockout for this fight.