### PR TITLE
Fix the tutorial splits by actually checking the setting for it

### DIFF
--- a/cuphead/src/lib.rs
+++ b/cuphead/src/lib.rs
@@ -298,7 +298,8 @@ async fn tick<'a>(
         } else if let Some((from_scene, target_scenes)) = level.split_on_scene_transition_to() {
             // split if the level transitions out to another specific scene (e.g. tutorial)
             split_log(
-                memory.scene.changed()?
+                level.is_split_enabled(settings)
+                    && memory.scene.changed()?
                     && previous_scene == from_scene
                     && target_scenes.contains(scene.as_str()),
                 &format!("scene change ({} -> {})", from_scene, scene.as_str()),


### PR DESCRIPTION
## What game?

Cuphead

## Why this change? What is the context?

#28 

## What did you change?

I added back the setting check for it. Must have accidentally removed this during a refactor.