### PR TITLE
Fix knockout split timing

### DIFF
--- a/cuphead/src/lib.rs
+++ b/cuphead/src/lib.rs
@@ -361,8 +361,8 @@ async fn tick<'a>(
             // split on knockout
             split_log(
                 level.is_split_enabled(settings)
-                    && memory.level_won.old().is_some_and(|w| !w)
                     && memory.level_won.current()?
+                    && memory.level_won.old().is_some_and(|w| !w)
                     && (!settings.split_highest_grade
                         || level.get_type().is_highest_grade(
                             memory.level_grade.current()?,


### PR DESCRIPTION
## What game?

Cuphead

## Why this change? What is the context?

[This](https://github.com/mitchell-merry/autosplitters-wasm/commit/ac4bf5a75a04e17675fb20e8198f648808b9d644) commit seems to have broken knockout split timing, specifically only on Release builds and not Debug builds. I believe the reason is that calling .old() on a Watcher isn't able to read the value of that memory address on the previous frame, unless .current() is called at some point.
Previous commits likely relied on the code that set the custom variables to actually get the value for level_won. SInce that code is now under a Debug compiler flag, and .old() got as part of an if statement before .current() could be called, Release builds could effectively never read the value for level_won.

## What did you change?

Swapped the order of operations lol
