### PR TITLE
[cuphead] feat: add setting to start timer on isle enter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,7 +36,7 @@ name = "asr-derive"
 version = "0.1.0"
 source = "git+https://github.com/mitchell-merry/asr?branch=some-helpers#f1f93cb650ca751d17f15ba0b8575958e36f3ec8"
 dependencies = [
- "heck",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
  "syn",
@@ -86,6 +86,8 @@ dependencies = [
  "bytemuck",
  "helpers",
  "once_cell",
+ "strum",
+ "strum_macros",
 ]
 
 [[package]]
@@ -123,6 +125,12 @@ name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "helpers"
@@ -304,6 +312,27 @@ dependencies = [
  "asr",
  "helpers",
  "zdoom",
+]
+
+[[package]]
+name = "strum"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/cuphead/Cargo.toml
+++ b/cuphead/Cargo.toml
@@ -8,6 +8,8 @@ asr = { workspace = true, features = ["alloc", "derive", "unity"] }
 bytemuck = "1.23.1"
 helpers = { path = "../helpers", features = ["unity"] }
 once_cell = "1.19.0"
+strum = { version = "0.28.0", features = ["derive"] }
+strum_macros = { version = "0.28.0", features = [] }
 
 [lib]
 crate-type = ["cdylib"]

--- a/cuphead/src/enums.rs
+++ b/cuphead/src/enums.rs
@@ -1,40 +1,40 @@
+use crate::scenes::Scene;
 use crate::settings::{ChessPieceSetting, Settings};
 use bytemuck::CheckedBitPattern;
 use once_cell::sync::Lazy;
 use std::collections::HashSet;
 
-static TUTORIAL_TARGETS: Lazy<HashSet<&'static str>> =
-    Lazy::new(|| HashSet::from(["scene_level_house_elder_kettle", "scene_map_world_1"]));
+static TUTORIAL_TARGETS: Lazy<HashSet<Scene>> =
+    Lazy::new(|| HashSet::from([Scene::LevelElderKettle, Scene::IsleOne]));
 
-static CHALICE_TUTORIAL_TARGETS: Lazy<HashSet<&'static str>> =
-    Lazy::new(|| HashSet::from(["scene_map_world_DLC"]));
+static CHALICE_TUTORIAL_TARGETS: Lazy<HashSet<Scene>> =
+    Lazy::new(|| HashSet::from([Scene::IsleDLC]));
 
-static MAUSOLEUM_TARGETS: Lazy<HashSet<&'static str>> = Lazy::new(|| {
+static MAUSOLEUM_TARGETS: Lazy<HashSet<Scene>> = Lazy::new(|| {
     HashSet::from([
-        "scene_map_world_1",
-        "scene_map_world_2",
-        "scene_map_world_3",
-        "scene_map_world_DLC",
+        Scene::IsleOne,
+        Scene::IsleTwo,
+        Scene::IsleThree,
+        Scene::IsleDLC,
     ])
 });
 
-static GRAVEYARD_TARGETS: Lazy<HashSet<&'static str>> =
-    Lazy::new(|| HashSet::from(["scene_map_world_DLC"]));
+static GRAVEYARD_TARGETS: Lazy<HashSet<Scene>> = Lazy::new(|| HashSet::from([Scene::IsleDLC]));
 
-static CHESS_PAWN_TARGETS: Lazy<HashSet<&'static str>> =
-    Lazy::new(|| HashSet::from(["scene_level_chess_castle", "scene_level_chess_knight"]));
+static CHESS_PAWN_TARGETS: Lazy<HashSet<Scene>> =
+    Lazy::new(|| HashSet::from([Scene::LevelChessCastle, Scene::LevelChessKnight]));
 
-static CHESS_KNIGHT_TARGETS: Lazy<HashSet<&'static str>> =
-    Lazy::new(|| HashSet::from(["scene_level_chess_castle", "scene_level_chess_bishop"]));
+static CHESS_KNIGHT_TARGETS: Lazy<HashSet<Scene>> =
+    Lazy::new(|| HashSet::from([Scene::LevelChessCastle, Scene::LevelChessBishop]));
 
-static CHESS_BISHOP_TARGETS: Lazy<HashSet<&'static str>> =
-    Lazy::new(|| HashSet::from(["scene_level_chess_castle", "scene_level_chess_rook"]));
+static CHESS_BISHOP_TARGETS: Lazy<HashSet<Scene>> =
+    Lazy::new(|| HashSet::from([Scene::LevelChessCastle, Scene::LevelChessRook]));
 
-static CHESS_ROOK_TARGETS: Lazy<HashSet<&'static str>> =
-    Lazy::new(|| HashSet::from(["scene_level_chess_castle", "scene_level_chess_queen"]));
+static CHESS_ROOK_TARGETS: Lazy<HashSet<Scene>> =
+    Lazy::new(|| HashSet::from([Scene::LevelChessCastle, Scene::LevelChessQueen]));
 
-static CHESS_QUEEN_TARGETS: Lazy<HashSet<&'static str>> =
-    Lazy::new(|| HashSet::from(["scene_level_chess_castle"]));
+static CHESS_QUEEN_TARGETS: Lazy<HashSet<Scene>> =
+    Lazy::new(|| HashSet::from([Scene::LevelChessCastle]));
 
 // these names come from code directly
 #[derive(CheckedBitPattern, Clone, Copy, Debug, Default, PartialEq, Eq)]
@@ -119,27 +119,25 @@ pub enum Levels {
 }
 
 impl Levels {
-    pub fn split_on_scene_transition_to(&self) -> Option<(&str, &'static HashSet<&'static str>)> {
+    pub fn split_on_scene_transition_to(&self) -> Option<(Scene, &'static HashSet<Scene>)> {
         match self {
-            Levels::Tutorial => Some(("scene_level_tutorial", &TUTORIAL_TARGETS)),
+            Levels::Tutorial => Some((Scene::LevelTutorial, &TUTORIAL_TARGETS)),
             Levels::ChaliceTutorial => {
-                Some(("scene_level_chalice_tutorial", &CHALICE_TUTORIAL_TARGETS))
+                Some((Scene::LevelChaliceTutorial, &CHALICE_TUTORIAL_TARGETS))
             }
             _ => None,
         }
     }
 
-    pub fn split_on_won_scene_transition_to(
-        &self,
-    ) -> Option<(&'static str, &'static HashSet<&'static str>)> {
+    pub fn split_on_won_scene_transition_to(&self) -> Option<(Scene, &'static HashSet<Scene>)> {
         match self {
-            Levels::Mausoleum => Some(("scene_level_mausoleum", &MAUSOLEUM_TARGETS)),
-            Levels::Graveyard => Some(("scene_level_graveyard", &GRAVEYARD_TARGETS)),
-            Levels::ChessPawn => Some(("scene_level_chess_pawn", &CHESS_PAWN_TARGETS)),
-            Levels::ChessKnight => Some(("scene_level_chess_knight", &CHESS_KNIGHT_TARGETS)),
-            Levels::ChessBishop => Some(("scene_level_chess_bishop", &CHESS_BISHOP_TARGETS)),
-            Levels::ChessRook => Some(("scene_level_chess_rook", &CHESS_ROOK_TARGETS)),
-            Levels::ChessQueen => Some(("scene_level_chess_queen", &CHESS_QUEEN_TARGETS)),
+            Levels::Mausoleum => Some((Scene::LevelMausoleum, &MAUSOLEUM_TARGETS)),
+            Levels::Graveyard => Some((Scene::LevelGraveyard, &GRAVEYARD_TARGETS)),
+            Levels::ChessPawn => Some((Scene::LevelChessPawn, &CHESS_PAWN_TARGETS)),
+            Levels::ChessKnight => Some((Scene::LevelChessKnight, &CHESS_KNIGHT_TARGETS)),
+            Levels::ChessBishop => Some((Scene::LevelChessBishop, &CHESS_BISHOP_TARGETS)),
+            Levels::ChessRook => Some((Scene::LevelChessRook, &CHESS_ROOK_TARGETS)),
+            Levels::ChessQueen => Some((Scene::LevelChessQueen, &CHESS_QUEEN_TARGETS)),
             _ => None,
         }
     }

--- a/cuphead/src/lib.rs
+++ b/cuphead/src/lib.rs
@@ -39,6 +39,7 @@ const STAR_SKIP_TIME_FIRST: Duration = Duration::from_millis(100);
 const STAR_SKIP_TIME_SECOND: Duration = Duration::from_millis(600);
 const STAR_SKIP_TIME_THIRD: Duration = Duration::from_millis(1100);
 
+#[derive(Default)]
 struct MeasuredState {
     last_seen_scene: Scene,
     level_updated_lsd: bool,
@@ -131,15 +132,7 @@ async fn try_load<'a>(process: &'a Process) -> Result<Cuphead<'a>, Box<dyn Error
 
     Ok(Cuphead {
         memory,
-        measured_state: MeasuredState {
-            last_seen_scene: Scene::Unknown(String::from("initial value")),
-            level_updated_lsd: Default::default(),
-            lsd_time: Default::default(),
-            difficulty_ticker_start_time: Default::default(),
-            difficulty_ticker_end_time: Default::default(),
-            star_skip_counter: Default::default(),
-            star_skip_counter_decimal: Default::default(),
-        },
+        measured_state: MeasuredState::default(),
     })
 }
 
@@ -158,10 +151,7 @@ async fn tick<'a>(
     let memory = &cuphead.memory;
     let measured_state = &mut cuphead.measured_state;
     let scene = memory.scene.current()?;
-    let previous_scene = memory
-        .scene
-        .old()
-        .unwrap_or(Scene::Unknown(String::from("empty previous scene")));
+    let previous_scene = memory.scene.old().unwrap_or(Scene::Invalid);
 
     if memory.scene.changed()? {
         measured_state.last_seen_scene = previous_scene.clone();

--- a/cuphead/src/lib.rs
+++ b/cuphead/src/lib.rs
@@ -39,7 +39,6 @@ const STAR_SKIP_TIME_FIRST: Duration = Duration::from_millis(100);
 const STAR_SKIP_TIME_SECOND: Duration = Duration::from_millis(600);
 const STAR_SKIP_TIME_THIRD: Duration = Duration::from_millis(1100);
 
-#[derive(Default)]
 struct MeasuredState {
     last_seen_scene: Scene,
     level_updated_lsd: bool,
@@ -132,7 +131,15 @@ async fn try_load<'a>(process: &'a Process) -> Result<Cuphead<'a>, Box<dyn Error
 
     Ok(Cuphead {
         memory,
-        measured_state: MeasuredState::default(),
+        measured_state: MeasuredState {
+            last_seen_scene: Scene::Unknown(String::from("initial value")),
+            level_updated_lsd: Default::default(),
+            lsd_time: Default::default(),
+            difficulty_ticker_start_time: Default::default(),
+            difficulty_ticker_end_time: Default::default(),
+            star_skip_counter: Default::default(),
+            star_skip_counter_decimal: Default::default(),
+        },
     })
 }
 
@@ -151,10 +158,13 @@ async fn tick<'a>(
     let memory = &cuphead.memory;
     let measured_state = &mut cuphead.measured_state;
     let scene = memory.scene.current()?;
-    let previous_scene = memory.scene.old().unwrap_or_default();
+    let previous_scene = memory
+        .scene
+        .old()
+        .unwrap_or(Scene::Unknown(String::from("empty previous scene")));
 
     if memory.scene.changed()? {
-        measured_state.last_seen_scene = previous_scene;
+        measured_state.last_seen_scene = previous_scene.clone();
     };
 
     if memory.lsd_time.changed()? && memory.lsd_time.current()? != 0f32 {

--- a/cuphead/src/lib.rs
+++ b/cuphead/src/lib.rs
@@ -151,7 +151,7 @@ async fn tick<'a>(
     let memory = &cuphead.memory;
     let measured_state = &mut cuphead.measured_state;
     let scene = memory.scene.current()?;
-    let previous_scene = memory.scene.old().unwrap_or(Scene::Invalid);
+    let previous_scene = memory.scene.old().unwrap_or_default();
 
     if memory.scene.changed()? {
         measured_state.last_seen_scene = previous_scene.clone();

--- a/cuphead/src/lib.rs
+++ b/cuphead/src/lib.rs
@@ -299,19 +299,25 @@ async fn tick<'a>(
         measured_state.star_skip_counter = 0;
         measured_state.star_skip_counter_decimal = 0;
 
-        let should_start = if scene == Scene::CutsceneIntro {
-            (memory.in_game.current()?
+        let should_start =
+            // Normal full game
+            (scene == Scene::CutsceneIntro && memory.in_game.current()?
                 // just started loading
-                && !memory.done_loading.current()?
-                && memory.done_loading.old().is_some_and(|l| l))
-                || (settings.individual_level_mode
-                    && memory.level_time.old().is_some_and(|t| t == 0f32)
-                    && memory.level_time.current()? > 0f32
-                    && (!memory.level_is_dice.current()? || memory.lsd_time.current()? == 0f32))
-        // } else if () {
-        } else {
-            false
-        };
+                && memory.is_loading()?
+                && memory.was_loading())
+            // ILs
+            || (settings.individual_level_mode
+                && memory.level_time.old().is_some_and(|t| t == 0f32)
+                && memory.level_time.current()? > 0f32
+                && (!memory.level_is_dice.current()? || memory.lsd_time.current()? == 0f32))
+            // Isle enters + NG+
+            || (settings.start_isle_enter
+                // just finished loading
+                && !memory.is_loading()?
+                && memory.was_loading()
+                && scene
+                    .isle_start_on_scene_transition_from()
+                    .is_some_and(|scenes| scenes.contains(&measured_state.last_seen_scene)));
 
         if should_start {
             set_variable("is run in progress", &format!("{}", true));

--- a/cuphead/src/lib.rs
+++ b/cuphead/src/lib.rs
@@ -1,11 +1,13 @@
 extern crate helpers;
 mod enums;
 mod memory;
+mod scenes;
 mod settings;
 mod util;
 
 use crate::enums::Mode;
 use crate::memory::Memory;
+use crate::scenes::Scene;
 use crate::settings::Settings;
 use crate::util::format_seconds;
 use asr::future::retry;
@@ -33,19 +35,13 @@ const PROCESS_NAMES: [&str; 2] = [
     "Cuphead",
 ];
 
-const SCENE_CUTSCENE_INTRO: &str = "scene_cutscene_intro";
-const SCENE_CUTSCENE_KING_DICE_CONTRACT: &str = "scene_cutscene_kingdice";
-const SCENE_CUTSCENE_DEVIL: &str = "scene_cutscene_devil";
-const SCENE_TITLE_SCREEN: &str = "scene_title";
-const SCENE_SCOREBOARD: &str = "scene_win";
-
 const STAR_SKIP_TIME_FIRST: Duration = Duration::from_millis(100);
 const STAR_SKIP_TIME_SECOND: Duration = Duration::from_millis(600);
 const STAR_SKIP_TIME_THIRD: Duration = Duration::from_millis(1100);
 
 #[derive(Default)]
 struct MeasuredState {
-    last_seen_scene: String,
+    last_seen_scene: Scene,
     level_updated_lsd: bool,
     lsd_time: f32,
     difficulty_ticker_start_time: Option<Instant>,
@@ -154,13 +150,11 @@ async fn tick<'a>(
 ) -> Result<(), Box<dyn Error>> {
     let memory = &cuphead.memory;
     let measured_state = &mut cuphead.measured_state;
-    let scene = String::from_utf16(memory.scene.current()?.as_slice())?;
-    let previous_scene = match memory.scene.old() {
-        Some(previous_scene) => String::from_utf16(previous_scene.as_slice())?,
-        None => String::new(),
-    };
+    let scene = memory.scene.current()?;
+    let previous_scene = memory.scene.old().unwrap_or_default();
+
     if memory.scene.changed()? {
-        measured_state.last_seen_scene = previous_scene.clone();
+        measured_state.last_seen_scene = previous_scene;
     };
 
     if memory.lsd_time.changed()? && memory.lsd_time.current()? != 0f32 {
@@ -192,7 +186,7 @@ async fn tick<'a>(
     };
 
     let mut is_run_in_progress: bool = false;
-    if state() == TimerState::Running && scene == SCENE_SCOREBOARD {
+    if state() == TimerState::Running && scene == Scene::Scoreboard {
         monitor_star_skip(memory, measured_state)?;
     }
     if state() != TimerState::NotRunning && state() != TimerState::Unknown {
@@ -305,16 +299,21 @@ async fn tick<'a>(
         measured_state.star_skip_counter = 0;
         measured_state.star_skip_counter_decimal = 0;
 
-        if (scene == SCENE_CUTSCENE_INTRO
-        && memory.in_game.current()?
-        // just started loading
-        && !memory.done_loading.current()?
-        && memory.done_loading.old().is_some_and(|l| l))
-            || (settings.individual_level_mode
-                && memory.level_time.old().is_some_and(|t| t == 0f32)
-                && memory.level_time.current()? > 0f32
-                && (!memory.level_is_dice.current()? || memory.lsd_time.current()? == 0f32))
-        {
+        let should_start = if scene == Scene::CutsceneIntro {
+            (memory.in_game.current()?
+                // just started loading
+                && !memory.done_loading.current()?
+                && memory.done_loading.old().is_some_and(|l| l))
+                || (settings.individual_level_mode
+                    && memory.level_time.old().is_some_and(|t| t == 0f32)
+                    && memory.level_time.current()? > 0f32
+                    && (!memory.level_is_dice.current()? || memory.lsd_time.current()? == 0f32))
+        // } else if () {
+        } else {
+            false
+        };
+
+        if should_start {
             set_variable("is run in progress", &format!("{}", true));
             pause_game_time();
             start();
@@ -336,15 +335,14 @@ async fn tick<'a>(
         }
 
         let level = memory.level.current()?;
-        let should_split = if scene == SCENE_CUTSCENE_KING_DICE_CONTRACT {
+        let should_split = if scene == Scene::CutsceneKingDice {
             // we do this first because the level is whatever the previous level was (usually Train)
             // so none of the level-specific logic makes sense
             split_log(
-                settings.split_kd_contract_cutscene
-                    && previous_scene != SCENE_CUTSCENE_KING_DICE_CONTRACT,
+                settings.split_kd_contract_cutscene && previous_scene != Scene::CutsceneKingDice,
                 "king dice contract",
             )
-        } else if scene == SCENE_CUTSCENE_DEVIL {
+        } else if scene == Scene::CutsceneDevil {
             split_log(
                 settings.split_devil_deal
                     && memory.devil_bad_ending_active.changed()?
@@ -363,8 +361,8 @@ async fn tick<'a>(
                     level.is_split_enabled(settings)
                         && memory.scene.changed()?
                         && previous_scene == from_scene
-                        && target_scenes.contains(scene.as_str()),
-                    &format!("scene change ({} -> {})", from_scene, scene.as_str()),
+                        && target_scenes.contains(&scene),
+                    &format!("scene change ({} -> {})", from_scene, &scene),
                 )
             } else {
                 // split on boss knockout
@@ -391,12 +389,8 @@ async fn tick<'a>(
                         && memory.done_loading.changed()?
                         && memory.is_loading()?
                         && measured_state.last_seen_scene == from_scene
-                        && target_scenes.contains(scene.as_str()),
-                    &format!(
-                        "scene change on fadeout ({} -> {})",
-                        from_scene,
-                        scene.as_str()
-                    ),
+                        && target_scenes.contains(&scene),
+                    &format!("scene change on fadeout ({} -> {})", from_scene, scene),
                 )
             } else if let Some((from_scene, target_scenes)) =
                 level.split_on_won_scene_transition_to()
@@ -408,11 +402,10 @@ async fn tick<'a>(
                         && memory.is_loading()?
                         && memory.level_won.current()?
                         && measured_state.last_seen_scene == from_scene
-                        && target_scenes.contains(scene.as_str()),
+                        && target_scenes.contains(&scene),
                     &format!(
                         "scene change on fadeout for a won level ({} -> {})",
-                        from_scene,
-                        scene.as_str()
+                        from_scene, scene
                     ),
                 )
             } else {
@@ -420,7 +413,7 @@ async fn tick<'a>(
                     level.is_split_enabled(settings)
                         && memory.done_loading.changed()?
                         && memory.is_loading()?
-                        && measured_state.last_seen_scene == "scene_win"
+                        && measured_state.last_seen_scene == Scene::Scoreboard
                         && (!settings.split_highest_grade
                             || level.get_type().is_highest_grade(
                                 memory.level_grade.current()?,
@@ -435,7 +428,7 @@ async fn tick<'a>(
             split();
         }
 
-        if scene == SCENE_TITLE_SCREEN && settings.auto_reset
+        if scene == Scene::TitleScreen && settings.auto_reset
             || settings.individual_level_mode && level_is_resetting
         {
             reset();

--- a/cuphead/src/memory.rs
+++ b/cuphead/src/memory.rs
@@ -73,7 +73,7 @@ impl<'a> Memory<'a> {
                 0,
                 &["<SceneName>k__BackingField", offsets.string_contents],
             )))
-            .default_given(Scene::Unknown(String::from("error reading scene"))),
+            .default_given(Scene::Invalid),
 
             in_game: Watcher::from(unity.path("PlayerData", 0, &["inGame"])).default_given(false),
             level: Watcher::from(unity.path("Level", 0, &["<PreviousLevel>k__BackingField"]))

--- a/cuphead/src/memory.rs
+++ b/cuphead/src/memory.rs
@@ -73,7 +73,7 @@ impl<'a> Memory<'a> {
                 0,
                 &["<SceneName>k__BackingField", offsets.string_contents],
             )))
-            .default_given(Scene::Unknown),
+            .default_given(Scene::Unknown(String::from("error reading scene"))),
 
             in_game: Watcher::from(unity.path("PlayerData", 0, &["inGame"])).default_given(false),
             level: Watcher::from(unity.path("Level", 0, &["<PreviousLevel>k__BackingField"]))

--- a/cuphead/src/memory.rs
+++ b/cuphead/src/memory.rs
@@ -1,8 +1,8 @@
 use crate::enums::Grade;
 use crate::enums::Levels;
 use crate::enums::Mode;
+use crate::scenes::{Scene, SceneGetter};
 use asr::game_engine::unity::scene_manager::SceneManager;
-use asr::string::ArrayWString;
 use asr::{Address64, PointerSize};
 use helpers::watchers::unity::{GameObjectActivePath, MonoBehaviourFieldPath, UnityImage};
 use helpers::watchers::Watcher;
@@ -32,7 +32,7 @@ impl Offsets {
 pub struct Memory<'a> {
     pub done_loading: Watcher<'a, bool>,
     pub insta: Watcher<'a, Address64>,
-    pub scene: Watcher<'a, ArrayWString<128>>,
+    pub scene: Watcher<'a, Scene>,
     pub in_game: Watcher<'a, bool>,
     pub level: Watcher<'a, Levels>,
     pub level_won: Watcher<'a, bool>,
@@ -68,12 +68,12 @@ impl<'a> Memory<'a> {
             ))
             .default_given(true),
             insta: Watcher::from(unity.path("SceneLoader", 0, &["_instance", "camera"])).default(),
-            scene: Watcher::from(unity.path(
+            scene: Watcher::from(SceneGetter::from(unity.path(
                 "SceneLoader",
                 0,
                 &["<SceneName>k__BackingField", offsets.string_contents],
-            ))
-            .default(),
+            )))
+            .default_given(Scene::Unknown),
 
             in_game: Watcher::from(unity.path("PlayerData", 0, &["inGame"])).default_given(false),
             level: Watcher::from(unity.path("Level", 0, &["<PreviousLevel>k__BackingField"]))

--- a/cuphead/src/memory.rs
+++ b/cuphead/src/memory.rs
@@ -218,4 +218,8 @@ impl<'a> Memory<'a> {
     pub fn is_loading(&self) -> Result<bool, Box<dyn Error>> {
         Ok(!self.done_loading.current()?)
     }
+
+    pub fn was_loading(&self) -> bool {
+        !self.done_loading.old().is_some_and(|l| l)
+    }
 }

--- a/cuphead/src/scenes.rs
+++ b/cuphead/src/scenes.rs
@@ -1,6 +1,8 @@
 use asr::string::ArrayWString;
 use helpers::watchers::unity::UnityPointerPath;
 use helpers::watchers::{ValueGetter, Watcher};
+use once_cell::sync::Lazy;
+use std::collections::HashSet;
 use std::error::Error;
 use std::str::FromStr;
 use strum::{Display, EnumString};
@@ -72,7 +74,35 @@ pub enum Scene {
 
     #[default]
     #[strum(to_string = "unknown scene")]
+    // TODO: we don't use the strum(default) attribute here because that requires giving this
+    // String, which means we can't use Copy, which the watcher code currently depends on
+    // perhaps we can refactor that to use Clone only which would work with this
     Unknown,
+}
+
+static ISLE_ONE_START_FROM: Lazy<HashSet<Scene>> =
+    Lazy::new(|| HashSet::from([Scene::LevelElderKettle, Scene::LevelTutorial]));
+
+static ISLE_TWO_START_FROM: Lazy<HashSet<Scene>> = Lazy::new(|| HashSet::from([Scene::IsleOne]));
+
+static ISLE_THREE_START_FROM: Lazy<HashSet<Scene>> = Lazy::new(|| HashSet::from([Scene::IsleTwo]));
+
+static ISLE_HELL_START_FROM: Lazy<HashSet<Scene>> = Lazy::new(|| HashSet::from([Scene::IsleThree]));
+
+static ISLE_DLC_START_FROM: Lazy<HashSet<Scene>> =
+    Lazy::new(|| HashSet::from([Scene::IsleOne, Scene::IsleTwo, Scene::IsleThree]));
+
+impl Scene {
+    pub fn isle_start_on_scene_transition_from(&self) -> Option<&'static HashSet<Scene>> {
+        match self {
+            Scene::IsleOne => Some(&ISLE_ONE_START_FROM),
+            Scene::IsleTwo => Some(&ISLE_TWO_START_FROM),
+            Scene::IsleThree => Some(&ISLE_THREE_START_FROM),
+            Scene::IsleHell => Some(&ISLE_HELL_START_FROM),
+            Scene::IsleDLC => Some(&ISLE_DLC_START_FROM),
+            _ => None,
+        }
+    }
 }
 
 pub struct SceneGetter<'a> {

--- a/cuphead/src/scenes.rs
+++ b/cuphead/src/scenes.rs
@@ -72,7 +72,9 @@ pub enum Scene {
     #[strum(serialize = "scene_level_chess_queen")]
     LevelChessQueen,
 
-    #[strum(default, to_string = "unknown scene ({0})")]
+    // NOTE: the run recap component depends on this just being the raw string name, even
+    // if it's not a scene we've seen (lol) before
+    #[strum(default, to_string = "{0}")]
     Unknown(String),
 
     #[default]

--- a/cuphead/src/scenes.rs
+++ b/cuphead/src/scenes.rs
@@ -1,0 +1,107 @@
+use asr::string::ArrayWString;
+use helpers::watchers::unity::UnityPointerPath;
+use helpers::watchers::{ValueGetter, Watcher};
+use std::error::Error;
+use std::str::FromStr;
+use strum::{Display, EnumString};
+
+#[derive(EnumString, Copy, Clone, Default, Display, PartialEq, Eq, Debug, Hash)]
+pub enum Scene {
+    #[strum(serialize = "scene_title")]
+    TitleScreen,
+
+    #[strum(serialize = "scene_cutscene_intro")]
+    CutsceneIntro,
+
+    #[strum(serialize = "scene_map_world_1")]
+    IsleOne,
+
+    #[strum(serialize = "scene_map_world_2")]
+    IsleTwo,
+
+    #[strum(serialize = "scene_map_world_3")]
+    IsleThree,
+
+    #[strum(serialize = "scene_map_world_4")]
+    IsleHell,
+
+    #[strum(serialize = "scene_map_world_DLC")]
+    IsleDLC,
+
+    #[strum(serialize = "scene_cutscene_kingdice")]
+    CutsceneKingDice,
+
+    #[strum(serialize = "scene_cutscene_devil")]
+    CutsceneDevil,
+
+    #[strum(serialize = "scene_win")]
+    Scoreboard,
+
+    #[strum(serialize = "scene_level_house_elder_kettle")]
+    LevelElderKettle,
+
+    #[strum(serialize = "scene_level_tutorial")]
+    LevelTutorial,
+
+    #[strum(serialize = "scene_level_chalice_tutorial")]
+    LevelChaliceTutorial,
+
+    #[strum(serialize = "scene_level_mausoleum")]
+    LevelMausoleum,
+
+    #[strum(serialize = "scene_level_graveyard")]
+    LevelGraveyard,
+
+    #[strum(serialize = "scene_level_chess_castle")]
+    LevelChessCastle,
+
+    #[strum(serialize = "scene_level_chess_pawn")]
+    LevelChessPawn,
+
+    #[strum(serialize = "scene_level_chess_knight")]
+    LevelChessKnight,
+
+    #[strum(serialize = "scene_level_chess_bishop")]
+    LevelChessBishop,
+
+    #[strum(serialize = "scene_level_chess_rook")]
+    LevelChessRook,
+
+    #[strum(serialize = "scene_level_chess_queen")]
+    LevelChessQueen,
+
+    #[default]
+    #[strum(to_string = "unknown scene")]
+    Unknown,
+}
+
+pub struct SceneGetter<'a> {
+    scene_str_getter: Box<dyn ValueGetter<ArrayWString<128>> + 'a>,
+}
+
+impl<'a> SceneGetter<'a> {
+    pub fn new(scene_str_getter: Box<dyn ValueGetter<ArrayWString<128>> + 'a>) -> Self {
+        SceneGetter { scene_str_getter }
+    }
+}
+
+impl<'a> From<UnityPointerPath<'a>> for SceneGetter<'a> {
+    fn from(value: UnityPointerPath<'a>) -> Self {
+        SceneGetter::new(Box::new(value))
+    }
+}
+
+impl<'a> ValueGetter<Scene> for SceneGetter<'a> {
+    fn get(&self) -> Result<Scene, Box<dyn Error>> {
+        let r = self.scene_str_getter.get()?;
+        let string = String::from_utf16(r.as_slice())?;
+
+        Ok(Scene::from_str(&string)?)
+    }
+}
+
+impl<'a> From<SceneGetter<'a>> for Watcher<'a, Scene> {
+    fn from(value: SceneGetter<'a>) -> Self {
+        Watcher::new(Box::new(value))
+    }
+}

--- a/cuphead/src/scenes.rs
+++ b/cuphead/src/scenes.rs
@@ -7,7 +7,7 @@ use std::error::Error;
 use std::str::FromStr;
 use strum::{Display, EnumString};
 
-#[derive(EnumString, Copy, Clone, Default, Display, PartialEq, Eq, Debug, Hash)]
+#[derive(EnumString, Clone, Display, PartialEq, Eq, Debug, Hash)]
 pub enum Scene {
     #[strum(serialize = "scene_title")]
     TitleScreen,
@@ -72,12 +72,8 @@ pub enum Scene {
     #[strum(serialize = "scene_level_chess_queen")]
     LevelChessQueen,
 
-    #[default]
-    #[strum(to_string = "unknown scene")]
-    // TODO: we don't use the strum(default) attribute here because that requires giving this
-    // String, which means we can't use Copy, which the watcher code currently depends on
-    // perhaps we can refactor that to use Clone only which would work with this
-    Unknown,
+    #[strum(default, to_string = "unknown scene ({0})")]
+    Unknown(String),
 }
 
 static ISLE_ONE_START_FROM: Lazy<HashSet<Scene>> =

--- a/cuphead/src/scenes.rs
+++ b/cuphead/src/scenes.rs
@@ -7,7 +7,7 @@ use std::error::Error;
 use std::str::FromStr;
 use strum::{Display, EnumString};
 
-#[derive(EnumString, Clone, Display, PartialEq, Eq, Debug, Hash)]
+#[derive(EnumString, Clone, Default, Display, PartialEq, Eq, Debug, Hash)]
 pub enum Scene {
     #[strum(serialize = "scene_title")]
     TitleScreen,
@@ -74,6 +74,10 @@ pub enum Scene {
 
     #[strum(default, to_string = "unknown scene ({0})")]
     Unknown(String),
+
+    #[default]
+    #[strum(to_string = "invalid scene")]
+    Invalid,
 }
 
 static ISLE_ONE_START_FROM: Lazy<HashSet<Scene>> =

--- a/cuphead/src/settings.rs
+++ b/cuphead/src/settings.rs
@@ -76,6 +76,11 @@ pub struct Settings {
     #[default = false]
     pub auto_reset: bool,
 
+    /// Start on entering an isle (for NG+ and isle runs)
+    ///
+    /// Starts when you enter an isle from a set of predefined locations.
+    pub start_isle_enter: bool,
+
     /// Display Star Skip Counter in decimal notation (half = 0.5, full = 1.0)
     ///
     /// For expert mode, 1 star = 0.33, 2 stars = 0.66, 3 stars = 1.0.

--- a/helpers/src/watchers/mod.rs
+++ b/helpers/src/watchers/mod.rs
@@ -33,14 +33,14 @@ impl<T: Copy> ValueGetter<T> for T {
 /// read a value from memory), and invalidate it at the end of the tick. During the tick, you can
 /// then observe how that value changed from the previous tick, and act on that behaviour (e.g.
 /// value went from false -> true, I should do something, i.e. start/pause/split the timer)
-pub struct Watcher<'a, T: Copy> {
+pub struct Watcher<'a, T: Clone> {
     source: Box<dyn ValueGetter<T> + 'a>,
     current: OnceCell<T>,
     old: Option<T>,
     default: Option<T>,
 }
 
-impl<'a, T: Copy> Watcher<'a, T> {
+impl<'a, T: Clone> Watcher<'a, T> {
     pub fn new(source: Box<dyn ValueGetter<T> + 'a>) -> Self {
         Self {
             source,
@@ -62,12 +62,12 @@ impl<'a, T: Copy> Watcher<'a, T> {
                 };
 
                 // Only return the error we got if we have no default
-                match self.default {
+                match self.default.clone() {
                     Some(default) => Ok(default),
                     None => Err(err),
                 }
             })
-            .copied()
+            .cloned()
     }
 
     /// Retrieve the previous value for this watcher.
@@ -77,7 +77,7 @@ impl<'a, T: Copy> Watcher<'a, T> {
     ///
     /// This returns `None` if there's no value to retrieve, otherwise returns `Some` if it can.
     pub fn old(&self) -> Option<T> {
-        self.old
+        self.old.clone()
     }
 
     /// Invalidate the watcher. This moves the value of `current` into `old`, and empties the cache
@@ -88,7 +88,7 @@ impl<'a, T: Copy> Watcher<'a, T> {
         // Is this desirable?
         // None of my code depends on this behaviour at the moment, since everything is read on
         // every tick anyway.
-        self.old = self.current.get().copied();
+        self.old = self.current.get().cloned();
         self.current = OnceCell::new();
     }
 
@@ -115,11 +115,11 @@ impl<T: Copy + 'static> Watcher<'_, T> {
     }
 }
 
-impl<'a, T: Copy + PartialEq> Watcher<'a, T> {
+impl<'a, T: Clone + PartialEq> Watcher<'a, T> {
     /// Simply tells you if the value changed. Requires reading the value from current, so this can
     /// return an Err.
     pub fn changed(&self) -> Result<bool, Box<dyn Error>> {
-        match self.old {
+        match self.old.clone() {
             None => Ok(false),
             Some(old) => Ok(old != self.current()?),
         }


### PR DESCRIPTION
## What game?

Cuphead

## Why this change? What is the context?

Fixes #43. Adds support for isle runs + NG+ run starts (but not NG+ run *endings*)

## What did you change?

- All scene reading now uses SceneGetter and the Scene enum, using `strum`
  - Watcher now depends on Clone rather than Copy to support the Unknown variant of that enum
- Added setting for this feature, and implement the simple logic
