### PR TITLE
[IAYB] Add IGT and RTA scenes as valid non-IL start points for non-story packs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,9 +75,9 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
-version = "2.10.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 dependencies = [
  "bytemuck",
  "serde_core",
@@ -85,9 +85,9 @@ dependencies = [
 
 [[package]]
 name = "bytemuck"
-version = "1.24.0"
+version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fbdf580320f38b612e485521afda1ee26d10cc9884efaaa750d383e13e3c5f4"
+checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
 dependencies = [
  "bytemuck_derive",
 ]
@@ -117,9 +117,9 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.5.5"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ececcb659e7ba858fb4f10388c250a7252eb0a27373f1a72b8748afdd248e587"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
 ]
@@ -215,21 +215,21 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.7.6"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "num-conv"
-version = "0.1.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "paste"
@@ -245,27 +245,27 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.103"
+version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ee95bc4ef87b8d5ba32e8b7714ccc834865276eab0aed5c9958d00ec45f49e8"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.42"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a338cc41d27e6cc6dce6cefc13a0729dfbb81c262b1f519331575dd80ef3067f"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
 name = "regex"
-version = "1.12.2"
+version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843bc0191f75f3e22651ae5f1e72939ab2f72a4bc30fa80a066bd66edefc24d4"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -275,9 +275,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -286,9 +286,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.8"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "ron"
@@ -374,9 +374,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.111"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "390cc9a294ab71bdb1aa2e99d13be9c753cd2d7bd6560c77118597410c4d2e87"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -395,9 +395,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.44"
+version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e7d9e3bb61134e77bde20dd4825b97c010155709965fedf0f49bb138e52a9d"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
  "num-conv",
@@ -407,15 +407,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.6"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40868e7c1d2f0b8d73e4a8c7f0ff63af4f6d19be117e90bd73eb1d62cf831c6b"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.22"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "wasi"

--- a/cuphead/src/lib.rs
+++ b/cuphead/src/lib.rs
@@ -471,39 +471,23 @@ fn monitor_star_skip(
 
     let diff: Duration = end.duration_since(start);
 
-    match memory.level_difficulty.current()? {
-        Mode::Easy => {
-            if diff < STAR_SKIP_TIME_FIRST {
-                measured_state.star_skip_counter += 1;
-                measured_state.star_skip_counter_decimal += 6;
-            }
-        }
+    // (absolute number of stars skipped, stars skipped as a fraction of 6)
+    let (increase_counter, increase_decimal_counter) = match memory.level_difficulty.current()? {
+        // simple - one skipped star is a full skip (6)
+        Mode::Easy if diff < STAR_SKIP_TIME_FIRST => (1, 6),
+        // regular - two skipped stars is a full skip (6), one is a half skip (3 = 6/2)
+        Mode::Normal if diff < STAR_SKIP_TIME_FIRST => (2, 6),
+        Mode::Normal if diff < STAR_SKIP_TIME_SECOND => (1, 3),
+        // regular - three skipped star is a full skip (6), one is a third skip (2 = 6/3)
+        Mode::Hard if diff < STAR_SKIP_TIME_FIRST => (3, 6),
+        Mode::Hard if diff < STAR_SKIP_TIME_SECOND => (2, 4),
+        Mode::Hard if diff < STAR_SKIP_TIME_THIRD => (1, 2),
+        // did not skip stars so don't increase counter
+        _ => (0, 0),
+    };
 
-        Mode::Normal => {
-            if diff < STAR_SKIP_TIME_FIRST {
-                measured_state.star_skip_counter += 2;
-                measured_state.star_skip_counter_decimal += 6;
-            } else if diff < STAR_SKIP_TIME_SECOND {
-                measured_state.star_skip_counter += 1;
-                measured_state.star_skip_counter_decimal += 3;
-            }
-        }
-
-        Mode::Hard => {
-            if diff < STAR_SKIP_TIME_FIRST {
-                measured_state.star_skip_counter += 3;
-                measured_state.star_skip_counter_decimal += 6;
-            } else if diff < STAR_SKIP_TIME_SECOND {
-                measured_state.star_skip_counter += 2;
-                measured_state.star_skip_counter_decimal += 4;
-            } else if diff < STAR_SKIP_TIME_THIRD {
-                measured_state.star_skip_counter += 1;
-                measured_state.star_skip_counter_decimal += 2;
-            }
-        }
-
-        _ => {}
-    }
+    measured_state.star_skip_counter += increase_counter;
+    measured_state.star_skip_counter_decimal += increase_decimal_counter;
 
     Ok(())
 }

--- a/i_am_your_beast/src/lib.rs
+++ b/i_am_your_beast/src/lib.rs
@@ -33,6 +33,24 @@ const SCENE_TUTORIAL_2: &str = "#01c_Special_Tutorial";
 const SCENE_WALKOUT: &str = "#2_Corridor_WabbitSeason";
 const SCENE_MERCY: &str = "#25_Special_Blinded";
 
+const SCENE_CHALLENGE_BABA_YAGA: &str = "#1_Challenge_FirstSteps";
+const SCENE_SG_PITCH_BLACK: &str = "#1_PLP_PitchBlack";
+const SCENE_CS_LIMBO: &str = "##_CS_Limbo";
+
+const RTA_SCENE_STARTS: &[&str] = &[
+    SCENE_TUTORIAL_1,
+    SCENE_CHALLENGE_BABA_YAGA,
+    SCENE_SG_PITCH_BLACK,
+    SCENE_CS_LIMBO,
+];
+
+const IGT_SCENE_STARTS: &[&str] = &[
+    SCENE_WALKOUT,
+    SCENE_CHALLENGE_BABA_YAGA,
+    SCENE_SG_PITCH_BLACK,
+    SCENE_CS_LIMBO,
+];
+
 #[derive(Default)]
 struct MeasuredState {
     total_igt: f32,
@@ -189,14 +207,16 @@ async fn tick<'a>(
         let should_start = if settings.use_in_game_time {
             let igt_just_started = memory.timer_started.changed_from_to(false, true)?;
 
-            igt_just_started && (settings.individual_level_mode || scene == SCENE_WALKOUT)
+            igt_just_started
+                && (settings.individual_level_mode || IGT_SCENE_STARTS.contains(&scene.as_str()))
         } else {
             let just_loaded_into_level = memory
                 .scene_transition_state
                 .is(SceneTransitionState::TransitioningIn)?
                 && memory.tracking.changed_from_to(false, true)?;
 
-            just_loaded_into_level && (settings.individual_level_mode || scene == SCENE_TUTORIAL_1)
+            just_loaded_into_level
+                && (settings.individual_level_mode || RTA_SCENE_STARTS.contains(&scene.as_str()))
         };
 
         if should_start {


### PR DESCRIPTION
## What game?

I am your beast

## Why this change? What is the context?

Previously it was not possible (even with the old splitter) to have the timer auto-start in full game mode on non-story packs.

## What did you change?

Support those packs by adding them as valid start points.
